### PR TITLE
feat/communityListSort - 커뮤니티 게시글 최신순 정렬 기능 추가

### DIFF
--- a/src/components/Contents/PostingMain/PostingList.tsx
+++ b/src/components/Contents/PostingMain/PostingList.tsx
@@ -16,7 +16,7 @@ const PostingList = () => {
   const categories = ['전체 글 보기', '잡담', '질문', '정보'];
   const supabase = createClient();
   const dayjs = require('dayjs');
-  const formatDate = (dateString: string) => dayjs(dateString).format('YY.MM.DD');
+  const formatDate = (dateString: Date) => dayjs(dateString).format('YY.MM.DD');
 
   const getPosts = async (selected: string) => {
     const { data, count } =
@@ -25,12 +25,22 @@ const PostingList = () => {
             .from('posts')
             .select('*, users(nickname)', { count: 'exact' })
             .range(ITEMS_PER_PAGE * (page - 1), ITEMS_PER_PAGE * (page - 1) + ITEMS_PER_PAGE - 1)
+            .order('updated_at', { ascending: false })
         : await supabase
             .from('posts')
             .select('*, users(nickname)', { count: 'exact' })
             .eq('category', selected)
-            .range(ITEMS_PER_PAGE * (page - 1), ITEMS_PER_PAGE * (page - 1) + ITEMS_PER_PAGE - 1);
-    return { data, count };
+            .range(ITEMS_PER_PAGE * (page - 1), ITEMS_PER_PAGE * (page - 1) + ITEMS_PER_PAGE - 1)
+            .order('updated_at', { ascending: false });
+
+    const kstOffset = 9 * 60 * 60 * 1000;
+    const postsWithKST = data?.map((post) => {
+      const updatedAtUTC = new Date(post.updated_at);
+      const updatedAtKST = new Date(updatedAtUTC.getTime() + kstOffset);
+      return { ...post, updated_at: updatedAtKST };
+    });
+
+    return { data: postsWithKST, count };
   };
 
   const {
@@ -108,7 +118,7 @@ const PostingList = () => {
                       </div>
                       <div className="flex justify-between w-full">
                         <p className="text-xs text-gray600">{item.users?.nickname}</p>
-                        <p className="text-xs text-gray600 pr-3">{formatDate(item.created_at)}</p>
+                        <p className="text-xs text-gray600 pr-3">{formatDate(item.updated_at)}</p>
                       </div>
                     </div>
                   </Link>

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,311 +1,295 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
   public: {
     Tables: {
       comments: {
         Row: {
-          content: string
-          created_at: string
-          id: number
-          post_id: string
-          user_id: string
-        }
+          content: string;
+          created_at: string;
+          id: number;
+          post_id: string;
+          user_id: string;
+        };
         Insert: {
-          content: string
-          created_at?: string
-          id?: number
-          post_id: string
-          user_id: string
-        }
+          content: string;
+          created_at?: string;
+          id?: number;
+          post_id: string;
+          user_id: string;
+        };
         Update: {
-          content?: string
-          created_at?: string
-          id?: number
-          post_id?: string
-          user_id?: string
-        }
+          content?: string;
+          created_at?: string;
+          id?: number;
+          post_id?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "comments_post_id_fkey"
-            columns: ["post_id"]
-            isOneToOne: false
-            referencedRelation: "posts"
-            referencedColumns: ["id"]
+            foreignKeyName: 'comments_post_id_fkey';
+            columns: ['post_id'];
+            isOneToOne: false;
+            referencedRelation: 'posts';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "comments_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["user_id"]
-          },
-        ]
-      }
+            foreignKeyName: 'comments_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['user_id'];
+          }
+        ];
+      };
       information: {
         Row: {
-          created_at: string
-          gender: string
-          height: number | null
-          id: string
-          purpose: string
-          result_diet: string | null
-          result_exercise: string | null
-          sync_user_data: boolean
-          user_id: string | null
-          weight: number | null
-          year_of_birth: number | null
-        }
+          created_at: string;
+          gender: string;
+          height: number | null;
+          id: string;
+          purpose: string;
+          result_diet: string | null;
+          result_exercise: string | null;
+          sync_user_data: boolean;
+          user_id: string | null;
+          weight: number | null;
+          year_of_birth: number | null;
+        };
         Insert: {
-          created_at?: string
-          gender: string
-          height?: number | null
-          id?: string
-          purpose: string
-          result_diet?: string | null
-          result_exercise?: string | null
-          sync_user_data?: boolean
-          user_id?: string | null
-          weight?: number | null
-          year_of_birth?: number | null
-        }
+          created_at?: string;
+          gender: string;
+          height?: number | null;
+          id?: string;
+          purpose: string;
+          result_diet?: string | null;
+          result_exercise?: string | null;
+          sync_user_data?: boolean;
+          user_id?: string | null;
+          weight?: number | null;
+          year_of_birth?: number | null;
+        };
         Update: {
-          created_at?: string
-          gender?: string
-          height?: number | null
-          id?: string
-          purpose?: string
-          result_diet?: string | null
-          result_exercise?: string | null
-          sync_user_data?: boolean
-          user_id?: string | null
-          weight?: number | null
-          year_of_birth?: number | null
-        }
+          created_at?: string;
+          gender?: string;
+          height?: number | null;
+          id?: string;
+          purpose?: string;
+          result_diet?: string | null;
+          result_exercise?: string | null;
+          sync_user_data?: boolean;
+          user_id?: string | null;
+          weight?: number | null;
+          year_of_birth?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "information_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["user_id"]
-          },
-        ]
-      }
+            foreignKeyName: 'information_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['user_id'];
+          }
+        ];
+      };
       posts: {
         Row: {
-          category: string
-          content: string
-          created_at: string
-          id: string
-          image_url: string[]
-          title: string
-          updated_at: string
-          user_id: string
-        }
+          category: string;
+          content: string;
+          created_at: string;
+          id: string;
+          image_url: string[];
+          title: string;
+          updated_at: Date;
+          user_id: string;
+        };
         Insert: {
-          category: string
-          content: string
-          created_at?: string
-          id?: string
-          image_url: string[]
-          title: string
-          updated_at?: string
-          user_id: string
-        }
+          category: string;
+          content: string;
+          created_at?: string;
+          id?: string;
+          image_url: string[];
+          title: string;
+          updated_at?: Date;
+          user_id: string;
+        };
         Update: {
-          category?: string
-          content?: string
-          created_at?: string
-          id?: string
-          image_url?: string[]
-          title?: string
-          updated_at?: string
-          user_id?: string
-        }
+          category?: string;
+          content?: string;
+          created_at?: string;
+          id?: string;
+          image_url?: string[];
+          title?: string;
+          updated_at?: Date;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "posts_user_id_fkey1"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["user_id"]
-          },
-        ]
-      }
+            foreignKeyName: 'posts_user_id_fkey1';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['user_id'];
+          }
+        ];
+      };
       result: {
         Row: {
-          breakfast: Json | null
-          created_at: string
-          dayofweek: string | null
-          dinner: Json | null
-          exercise: string | null
-          id: number
-          lunch: Json | null
-          total_calorie: string | null
-          user_id: string | null
-        }
+          breakfast: Json | null;
+          created_at: string;
+          dayofweek: string | null;
+          dinner: Json | null;
+          exercise: string | null;
+          id: number;
+          lunch: Json | null;
+          total_calorie: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          breakfast?: Json | null
-          created_at?: string
-          dayofweek?: string | null
-          dinner?: Json | null
-          exercise?: string | null
-          id?: number
-          lunch?: Json | null
-          total_calorie?: string | null
-          user_id?: string | null
-        }
+          breakfast?: Json | null;
+          created_at?: string;
+          dayofweek?: string | null;
+          dinner?: Json | null;
+          exercise?: string | null;
+          id?: number;
+          lunch?: Json | null;
+          total_calorie?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          breakfast?: Json | null
-          created_at?: string
-          dayofweek?: string | null
-          dinner?: Json | null
-          exercise?: string | null
-          id?: number
-          lunch?: Json | null
-          total_calorie?: string | null
-          user_id?: string | null
-        }
-        Relationships: []
-      }
+          breakfast?: Json | null;
+          created_at?: string;
+          dayofweek?: string | null;
+          dinner?: Json | null;
+          exercise?: string | null;
+          id?: number;
+          lunch?: Json | null;
+          total_calorie?: string | null;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
       users: {
         Row: {
-          email: string
-          is_survey_done: boolean
-          nickname: string
-          profile_url: string | null
-          user_id: string
-        }
+          email: string;
+          is_survey_done: boolean;
+          nickname: string;
+          profile_url: string | null;
+          user_id: string;
+        };
         Insert: {
-          email: string
-          is_survey_done?: boolean
-          nickname: string
-          profile_url?: string | null
-          user_id?: string
-        }
+          email: string;
+          is_survey_done?: boolean;
+          nickname: string;
+          profile_url?: string | null;
+          user_id?: string;
+        };
         Update: {
-          email?: string
-          is_survey_done?: boolean
-          nickname?: string
-          profile_url?: string | null
-          user_id?: string
-        }
+          email?: string;
+          is_survey_done?: boolean;
+          nickname?: string;
+          profile_url?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
+            foreignKeyName: 'user_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       delete_user: {
         Args: {
-          user_id: string
-        }
-        Returns: undefined
-      }
-    }
+          user_id: string;
+        };
+        Returns: undefined;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type PublicSchema = Database[Extract<keyof Database, 'public'>];
 
 export type Tables<
-  PublicTableNameOrOptions extends
-  | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-  | { schema: keyof Database },
+  PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views']) | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-  ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-    Database[PublicTableNameOrOptions["schema"]]["Views"])
-  : never = never,
+    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+        Database[PublicTableNameOrOptions['schema']]['Views'])
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-    Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
     }
-  ? R
-  : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-    PublicSchema["Views"])
-  ? (PublicSchema["Tables"] &
-    PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-      Row: infer R
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+  ? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
+      Row: infer R;
     }
-  ? R
-  : never
-  : never
+    ? R
+    : never
+  : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
-  | keyof PublicSchema["Tables"]
-  | { schema: keyof Database },
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-  ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-  : never = never,
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-    Insert: infer I
-  }
-  ? I
-  : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-    Insert: infer I
-  }
-  ? I
-  : never
-  : never
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
-  | keyof PublicSchema["Tables"]
-  | { schema: keyof Database },
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-  ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-  : never = never,
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-    Update: infer U
-  }
-  ? U
-  : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-    Update: infer U
-  }
-  ? U
-  : never
-  : never
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends
-  | keyof PublicSchema["Enums"]
-  | { schema: keyof Database },
+  PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-  : never = never,
+    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
+    : never = never
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-  : never
+  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
+  ? PublicSchema['Enums'][PublicEnumNameOrOptions]
+  : never;


### PR DESCRIPTION
## 작업 내용
커뮤니티 게시글 최신순 정렬 기능 추가
<br><br>

## 참고 사항

- 업데이트 시간(수정시간) 기준 최신순으로 정렬 했습니다.
- posts 테이블의 updated_at이 UTC로 되어있어 한국시간으로 변경하는 로직 추가했습니다.

<br><br>

## 관련 이슈

- Close #264 

<br><br>
